### PR TITLE
processors/github_metadata: use pushed_at instead of updated_at

### DIFF
--- a/hecat/processors/github_metadata.py
+++ b/hecat/processors/github_metadata.py
@@ -76,7 +76,7 @@ def add_github_metadata(step):
                     logging.info('Missing metadata for %s, gathering it from Github API', software['name'])
                     gh_metadata = get_gh_metadata(github_url, g)
                     software['stargazers_count'] = gh_metadata.stargazers_count
-                    software['updated_at'] = datetime.strftime(gh_metadata.updated_at, "%Y-%m-%d")
+                    software['updated_at'] = datetime.strftime(gh_metadata.pushed_at, "%Y-%m-%d")
                     software['archived'] = gh_metadata.archived
                     write_software_yaml(step, software)
                 else:


### PR DESCRIPTION
processors/github_metadata: use pushed_at instead of updated_at to identify the date of last update to a software project

- updated_at seems to reflect the date of last change (description, issues, comments, PRs, ...) to a repository, but we want the date of last commit to the default branch.
- ref. https://github.com/nodiscc/hecat/issues/53
- the YAML key name updated_at remains unchanged