### PR TITLE
importers/shaarli_api: sort the output data by reverse creation date by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ steps:
         output_file: shaarli.yml
         skip_existing: True # (default True) skip importing items whose 'url:' already exists in the output file
         clean_removed: False # (default False) remove items from the output file, whose 'url:' was not found in the input file
+        sort_by: created # (default 'created') key by which to sort the output list
+        sort_reverse: True # (default True) sort the output list in reverse order
 
   - name: download video files
       module: processors/download_media

--- a/hecat/importers/shaarli_api.py
+++ b/hecat/importers/shaarli_api.py
@@ -13,6 +13,8 @@ steps:
       output_file: shaarli.yml
       skip_existing: True # (default True) skip importing items whose 'url:' already exists in the output file
       clean_removed: False # (default False) remove items from the output file, whose 'url:' was not found in the input file
+      sort_by: created # (default 'created') key by which to sort the output list
+      sort_reverse: True # (default True) sort the output list in reverse order
 
 Source directory structure:
 └── shaarli.json
@@ -37,12 +39,18 @@ def import_shaarli_json(step):
         step['module_options']['skip_existing'] = True
     if 'clean_removed' not in step['module_options']:
         step['module_options']['clean_removed'] = False
+    if 'sort_by' not in step['module_options']:
+        step['module_options']['sort_by'] = 'created'
+    if 'sort_reverse' not in step['module_options']:
+        step['module_options']['sort_reverse'] = True
     with open(step['module_options']['source_file'], 'r', encoding="utf-8") as json_file:
         new_data = json.load(json_file)
     if os.path.exists(step['module_options']['output_file']) and step['module_options']['skip_existing']:
         logging.info('loading existing data from %s', step['module_options']['output_file'])
         previous_data = load_yaml_data(step['module_options']['output_file'])
-        final_data = sorted({x["url"]: x for x in (new_data + previous_data)}.values(), key=lambda x: x["url"])
+        final_data = sorted({x["url"]: x for x in (new_data + previous_data)}.values(),
+                             key=lambda x: x[step['module_options']['sort_by']],
+                             reverse=step['module_options']['sort_reverse'])
         with open(step['module_options']['output_file'], 'w+', encoding="utf-8") as yaml_file:
             logging.info('writing file %s', step['module_options']['output_file'])
             yaml.dump(final_data, yaml_file)

--- a/tests/.hecat.import_shaarli.yml
+++ b/tests/.hecat.import_shaarli.yml
@@ -6,3 +6,11 @@ steps:
       output_file: tests/shaarli.yml
       skip_existing: True
       clean_removed: True
+
+  - name: import updated shaarli data
+    module: importers/shaarli_api
+    module_options:
+      source_file: tests/shaarli-duplicate.json
+      output_file: tests/shaarli.yml
+      skip_existing: True
+      clean_removed: True

--- a/tests/.hecat.import_shaarli.yml
+++ b/tests/.hecat.import_shaarli.yml
@@ -1,5 +1,5 @@
 steps:
-  - name: import_shaarli
+  - name: import shaarli data
     module: importers/shaarli_api
     module_options:
       source_file: tests/shaarli.json

--- a/tests/shaarli-duplicate.json
+++ b/tests/shaarli-duplicate.json
@@ -1,0 +1,114 @@
+[
+    {
+        "hecat_comment": "test for nodl tag, should not be downloaded",
+        "created": "2022-07-27T22:56:06+02:00",
+        "description": "",
+        "id": 6624, 
+        "private": false,
+        "shorturl": "zKVXxA",
+        "tags": [
+            "video",
+            "vj",
+            "math",
+            "nodl"
+        ],
+        "title": "The Burning Ship - A Fractal Zoom (5e598) (4k 60fps) - YouTube",
+        "updated": "2022-07-29T14:15:39+02:00",
+        "url": "https://www.youtube.com/watch?v=2S3lc2G3rWs"
+    },
+    {
+        "hecat_comment": "test duplicate/updated entry",
+        "created": "2022-07-27T22:16:37+02:00",
+        "description": "A test description - updated. This is the same item as id: 6623 in shaarli.json, but the description has been updated",
+        "id": 6623,
+        "private": false,
+        "shorturl": "U-sj1Z",
+        "tags": [
+            "lecture",
+            "space",
+            "readlater"
+        ],
+        "title": "SMACS J0723.3\u20137327 - Wikipedia - updated/duplicate",
+        "updated": "2022-07-27T22:18:55+02:01",
+        "url": "https://en.wikipedia.org/wiki/SMACS_J0723.3%E2%80%937327"
+    },
+    {
+        "created": "2020-07-23T19:54:15+02:00",
+        "description": "```\r\n   rescue:\r\n     - debug:\r\n         msg: 'I caught an error, can do stuff here to fix it, :-)'\r\n   always:\r\n     - debug:\r\n         msg: \"This always executes, :-)\"\r\n```",
+        "id": 232,
+        "private": false,
+        "shorturl": "oJmZFg",
+        "tags": [
+            "doc",
+            "admin",
+            "ansible"
+        ],
+        "title": "Blocks \u2014 Ansible Documentation",
+        "updated": "2023-01-25T15:02:16+01:00",
+        "url": "https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_blocks.html"
+    },
+    {
+        "created": "2017-07-13T03:05:20+02:00",
+        "description": "&gt;    That gibberish he talked was Cityspeak, gutter talk, a mishmash of Japanese, Spanish, German, what have you. I didn\u2019t really need a translator. I knew the lingo, every good cop did. But I wasn\u2019t going to make it easier for him.",
+        "id": 2083,
+        "private": false,
+        "shorturl": "Bl8mkA",
+        "tags": [
+            "games",
+            "cyberpunk"
+        ],
+        "title": "Cityspeak | Off-world: The Blade Runner Wiki | FANDOM powered by Wikia",
+        "updated": "2022-11-11T15:13:56+01:00",
+        "url": "http://bladerunner.wikia.com/wiki/Cityspeak"
+    },
+    {
+        "hecat_comment": "test for download_media module with only_audio: True",
+        "created": "2022-07-26T15:25:28+02:00",
+        "description": "",
+        "id": 6610,
+        "private": false,
+        "shorturl": "Ghy1Yg",
+        "tags": [
+            "music",
+            "acoustic",
+            "folk"
+        ],
+        "title": "youtube-dl test video \"\\'/\\ä↭𝕐 - YouTube",
+        "updated": "2022-07-26T15:26:33+02:00",
+        "url": "https://www.youtube.com/watch?v=BaW_jenozKc"
+    },
+    {
+        "created": "2021-04-27T21:07:20+02:00",
+        "description": "- https://docs.graylog.org/en/4.0/pages/installation/os/debian.html\r\n- https://docs.graylog.org/en/4.0/pages/getting_started/web_console.html\r\n- https://docs.graylog.org/en/4.0/pages/getting_started.html\r\n- https://docs.graylog.org/en/4.0/pages/getting_started/planning.html\r\n- https://docs.graylog.org/en/4.0/pages/getting_started/download_install.html\r\n- https://docs.graylog.org/en/4.0/pages/getting_started/configure.html\r\n- https://docs.graylog.org/en/4.0/pages/installation.html\r\n- https://gettingstarted.graylog.org/assets/v3/guides/1-first_messages.html\r\n- https://gettingstarted.graylog.org/assets/v3/guides/2-do_something.html\r\n - https://gettingstarted.graylog.org/assets/v3/guides/3-dashboards.ftl\r\n- https://gettingstarted.graylog.org/assets/v3/guides/4-alerts.ftl\r\n- https://marketplace.graylog.org/\r\n- https://buzut.net/analysez-vos-logs-graylog/\r\n- https://www.graylog.org/products/open-source-vs-enterprise\r\n- https://docs.graylog.org/en/4.0/pages/configuration/server.conf.html\r\n- https://docs.graylog.org/en/4.0/pages/streams.html\r\n- https://docs.graylog.org/en/4.0/pages/configuration/elasticsearch.html\r\n- https://docs.graylog.org/en/4.0/pages/configuration/index_model.html\r\n- https://www.graylog.org/products/open-source\r\n- https://docs.graylog.org/en/4.0/pages/sending_data.html\r\n- https://docs.graylog.org/en/4.0/pages/sending/syslog.html\r\n- https://docs.graylog.org/en/4.0/pages/queries.html\r\n- https://docs.graylog.org/en/4.0/pages/dashboards.html\r\n- https://docs.graylog.org/en/4.0/pages/extractors.html\r\n- https://docs.graylog.org/en/4.0/pages/alerts.html\r\n- https://sujets-libres.fr/index.php?article263/graylog-a-l-usage-retour-d-utilisation\r\n- https://logz.io/blog/logstash-grok/\r\n- https://docs.graylog.org/docs/streams\r\n- https://www.vdalabs.com/no-more-secrets-logging-made-easy-through-graylog-part-7/\r\n- https://docs.graylog.org/docs/decorators\r\n- https://docs.graylog.org/docs/lookuptables\r\n- https://community.graylog.org/t/hide-overall-count-from-line-chart/13843\r\n- https://docs.graylog.org/docs/processing-pipelines\r\n- https://docs.graylog.org/docs/pipelines\r\n- https://docs.graylog.org/docs/rules\r\n- https://docs.graylog.org/docs/functions-index\r\n- https://docs.graylog.org/docs/functions#expand-syslog-priority\r\n- https://community.graylog.org/t/stream-pipeline-and-input-extractor-clarification/5655\r\n- https://community.graylog.org/t/pipeline-rule-to-set-facility-and-log-level-categories/21100/2\r\n- https://serverfault.com/questions/822886/graylog-fields-from-pipeline-rule-not-showing-up-in-search-data\r\n- https://docs.graylog.org/docs/extractors\r\n- https://old.reddit.com/r/graylog/\r\n\r\n### Some title\r\n\r\nexample text **example bold text**",
+        "id": 4727,
+        "private": false,
+        "shorturl": "dvrYJA",
+        "tags": [
+            "doc",
+            "admin",
+            "logs",
+            "monitoring"
+        ],
+        "title": "Welcome to the Graylog documentation \u2014 Graylog 4.0.0 documentation",
+        "updated": "2023-01-22T02:38:27+01:00",
+        "url": "https://docs.graylog.org/en/4.0/index.html"
+    },
+    {
+        "hecat_comment": "test for download_media module",
+        "created": "2022-07-26T15:24:45+02:00",
+        "description": "",
+        "id": 6609,
+        "private": false,
+        "shorturl": "wInSrw",
+        "tags": [
+            "video",
+            "games",
+            "soundtrack",
+            "album",
+            "downtempo"
+        ],
+        "title": "youtube-dl test video \"\\'/\\ä↭𝕐 - YouTube",
+        "updated": "2022-07-26T15:26:33+02:00",
+        "url": "https://www.youtube.com/watch?v=BaW_jenozKc"
+    }
+]


### PR DESCRIPTION
- make sort key and order configurable (`sort_by`, `sort_reverse` module options)
- fixes https://github.com/nodiscc/hecat/issues/81
- tests: importers/shaarli_api: add initial test data for importing duplicate/updated data