### PR TITLE
processors/github_metadata: allow sleeping for a configurable amount of time period before each Github API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ steps:
     module_options:
       source_directory: awesome-selfhosted-data
       gh_metadata_only_missing: True # optional, default False
+      sleep_time: 7.3
 
   - name: check data against awesome-selfhosted guidelines
     module: processors/awesome_lint

--- a/tests/.hecat.github_metadata.yml
+++ b/tests/.hecat.github_metadata.yml
@@ -4,3 +4,4 @@ steps:
     module_options:
       source_directory: awesome-selfhosted-data
       gh_metadata_only_missing: True
+      sleep_time: 7.3


### PR DESCRIPTION
- fixes #97