### PR TITLE
processors/awesome_lint: check_github_last_updated: make the number of days without updates before triggering an info/warning/error message configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+#### [v1.1.0](https://github.com/nodiscc/hecat/releases#1.1.0) - UNRELEASED
+
+**Added:**
+- processors/awesome_lint: allow confguring the number of days without updates to a project before triggering an info/warning/error message (`last_updated_{error,warn,info}_days`, default to 3650, 365, 186 respectively)
+
+---------------------
+
 #### [v1.0.2](https://github.com/nodiscc/hecat/releases#1.0.2) - 2023-07-27
 
 **Changed:**

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test_update_github_metadata: install
 	hecat --config tests/.hecat.github_metadata.yml
 
 .PHONY: test_awesome_lint # test linter/compliance checker on awesome-sefhosted-data
-test_awesome_lint:
+test_awesome_lint: install
 	source .venv/bin/activate && \
 	hecat --config tests/.hecat.awesome_lint.yml
 

--- a/hecat/main.py
+++ b/hecat/main.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 from .utils import load_yaml_data
 from .importers import import_markdown_awesome, import_shaarli_json
-from .processors import add_github_metadata, awesome_lint, check_github_last_updated, check_urls,download_media
+from .processors import add_github_metadata, awesome_lint, check_urls, download_media
 from .exporters import render_markdown_singlepage, render_html_table
 from .exporters import render_markdown_multipage
 
@@ -39,7 +39,6 @@ def main():
             add_github_metadata(step)
         elif step['module'] == 'processors/awesome_lint':
             awesome_lint(step)
-            check_github_last_updated(step)
         elif step['module'] == 'processors/url_check':
             check_urls(step)
         elif step['module'] == 'processors/download_media':

--- a/hecat/processors/__init__.py
+++ b/hecat/processors/__init__.py
@@ -1,5 +1,5 @@
 """processors"""
 from .github_metadata import add_github_metadata
-from .awesome_lint import awesome_lint, check_github_last_updated
+from .awesome_lint import awesome_lint
 from .download_media import download_media
 from .url_check import check_urls

--- a/tests/.hecat.awesome_lint.yml
+++ b/tests/.hecat.awesome_lint.yml
@@ -4,6 +4,9 @@ steps:
     module_options:
       source_directory: tests/awesome-selfhosted-data
       items_in_redirect_fatal: False
+      # last_updated_error_days: 3650 # (optional, default 3650) raise an error message for projects that have not been updated in this number of days
+      # last_updated_warn_days: 365 # (optional, default 365) raise a warning message for projects that have not been updated in this number of days
+      # last_updated_info_days: 186 # (optional, default 186) raise an info message for projects that have not been updated in this number of days
       licenses_files:
         - licenses.yml
         - licenses-nonfree.yml


### PR DESCRIPTION
-  (`last_updated_{error,warn,info}_days`)
- default to 3650, 365, 186 respectively
- ref. https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/50
- rename function to `check_last_updated`