### PR TITLE
processors/awesome_lint: exit with error if any `software` item uses a tag for which `redirect:` is not empty, or if any tag has less than 3 software items attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 #### [v1.1.2](https://github.com/nodiscc/hecat/releases/tag/1.1.2) - UNRELEASED
 
+**Changed:**
+- processors/awesome_lint: if `items_in_redirect_fatal: True` (the default), exit with error if any `software` item uses a tag for which `redirect:` is not empty
+
 **Fixed:**
 - processors/awesome_lint: fix detection of `redirect` attribute when a tag has least than N items
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 **Changed:**
 - processors/awesome_lint: if `items_in_redirect_fatal: True` (the default), exit with error if any `software` item uses a tag for which `redirect:` is not empty
-- processors/awesome_lint: always fail if any tag has less than 3 software items attached to it
+- processors/awesome_lint: always fail if any `tag` item has less than 3 `software` items referencing it
+- processors/awesome_lint: run checks on `tag` items before checks on `software` items
 
 **Fixed:**
 - processors/awesome_lint: fix detection of `redirect` attribute when a tag has least than N items
-- processors/awesome_lint: don't error if a tag with the redirect attribute has 0 matching items
+- processors/awesome_lint: don't error if a tag with the redirect attribute has 0 matching `software` items
 
 ---------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 **Changed:**
 - processors/awesome_lint: if `items_in_redirect_fatal: True` (the default), exit with error if any `software` item uses a tag for which `redirect:` is not empty
+- processors/awesome_lint: always fail if any tag has less than 3 software items attached to it
 
 **Fixed:**
 - processors/awesome_lint: fix detection of `redirect` attribute when a tag has least than N items

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 **Fixed:**
 - processors/awesome_lint: fix detection of `redirect` attribute when a tag has least than N items
+- processors/awesome_lint: don't error if a tag with the redirect attribute has 0 matching items
 
 ---------------------
 

--- a/hecat/processors/awesome_lint.py
+++ b/hecat/processors/awesome_lint.py
@@ -214,6 +214,10 @@ def awesome_lint(step):
         if 'redirect' in tag and tag['redirect']:
             tags_with_redirect.append(tag['name'])
     errors = []
+    for tag in tags_list:
+        check_related_tags_in_tags_list(tag, tags_list, errors)
+        check_required_fields(tag, errors, required_fields=TAGS_REQUIRED_FIELDS, severity=logging.warning)
+        check_tag_has_at_least_items(tag, software_list, tags_with_redirect, errors, min_items=3)
     for software in software_list:
         check_required_fields(software, errors, required_fields=SOFTWARE_REQUIRED_FIELDS, required_lists=SOFTWARE_REQUIRED_LISTS)
         check_description_syntax(software, errors)
@@ -223,10 +227,6 @@ def awesome_lint(step):
         check_external_link_syntax(software, errors)
         check_not_archived(software, errors)
         check_last_updated(software, step, errors)
-    for tag in tags_list:
-        check_related_tags_in_tags_list(tag, tags_list, errors)
-        check_required_fields(tag, errors, required_fields=TAGS_REQUIRED_FIELDS, severity=logging.warning)
-        check_tag_has_at_least_items(tag, software_list, tags_with_redirect, errors, min_items=3)
     for license in licenses_list:
         check_required_fields(license, errors, required_fields=LICENSES_REQUIRED_FIELDS)
     if errors:

--- a/hecat/processors/awesome_lint.py
+++ b/hecat/processors/awesome_lint.py
@@ -126,7 +126,7 @@ def check_related_tags_in_tags_list(tag, tags_list, errors):
                 message = "{}: related tag {} is not listed in the main tags list".format(tag['name'], related_tag_name)
                 log_exception(message, errors)
 
-def check_tag_has_at_least_items(tag, software_list, errors, min_items=3):
+def check_tag_has_at_least_items(tag, software_list, tags_with_redirect, errors, min_items=3):
     """check that a tag has at least N software items attached to it"""
     tag_items_count = 0
     for software in software_list:
@@ -136,8 +136,11 @@ def check_tag_has_at_least_items(tag, software_list, errors, min_items=3):
         assert tag_items_count >= min_items
         logging.debug('{} items tagged {}'.format(tag_items_count, tag['name']))
     except AssertionError:
-        message = "{} items tagged {}, each tag must have at least {} items attached".format(tag_items_count, tag['name'], min_items)
-        log_exception(message, errors)
+        if tag['name'] in tags_with_redirect and tag_items_count == 0:
+            logging.debug('0 items tagged {}, but this tag has the redirect attribute set'.format(tag['name']))
+        else:
+            message = "{} items tagged {}, each tag must have at least {} items attached".format(tag_items_count, tag['name'], min_items)
+            log_exception(message, errors)
 
 def check_redirect_sections_empty(step, software, tags_with_redirect, errors):
     """check that any tag in the tags list does not match a tag with redirect set"""
@@ -223,7 +226,7 @@ def awesome_lint(step):
     for tag in tags_list:
         check_related_tags_in_tags_list(tag, tags_list, errors)
         check_required_fields(tag, errors, required_fields=TAGS_REQUIRED_FIELDS, severity=logging.warning)
-        check_tag_has_at_least_items(tag, software_list, errors, min_items=3)
+        check_tag_has_at_least_items(tag, software_list, tags_with_redirect, errors, min_items=3)
     for license in licenses_list:
         check_required_fields(license, errors, required_fields=LICENSES_REQUIRED_FIELDS)
     if errors:

--- a/hecat/processors/awesome_lint.py
+++ b/hecat/processors/awesome_lint.py
@@ -126,21 +126,18 @@ def check_related_tags_in_tags_list(tag, tags_list, errors):
                 message = "{}: related tag {} is not listed in the main tags list".format(tag['name'], related_tag_name)
                 log_exception(message, errors)
 
-def check_tag_has_at_least_items(tag, software_list, errors, minitems=3):
+def check_tag_has_at_least_items(tag, software_list, errors, min_items=3):
     """check that a tag has at least N software items attached to it"""
     tag_items_count = 0
     for software in software_list:
         if tag['name'] in software['tags']:
             tag_items_count += 1
     try:
-        assert tag_items_count >= minitems
+        assert tag_items_count >= min_items
         logging.debug('{} items tagged {}'.format(tag_items_count, tag['name']))
     except AssertionError:
-        if not 'redirect' in tag:
-            message = "{} items tagged {}, each tag must have at least {} items attached".format(tag_items_count, tag['name'], minitems)
-            log_exception(message, errors)
-        else:
-            logging.debug('{} items tagged {}, less than {} but ignoring since this tag is redirected'.format(tag_items_count, tag['name'], minitems))
+        message = "{} items tagged {}, each tag must have at least {} items attached".format(tag_items_count, tag['name'], min_items)
+        log_exception(message, errors)
 
 def check_redirect_sections_empty(step, software, tags_with_redirect, errors):
     """check that any tag in the tags list does not match a tag with redirect set"""
@@ -226,7 +223,7 @@ def awesome_lint(step):
     for tag in tags_list:
         check_related_tags_in_tags_list(tag, tags_list, errors)
         check_required_fields(tag, errors, required_fields=TAGS_REQUIRED_FIELDS, severity=logging.warning)
-        check_tag_has_at_least_items(tag, software_list, errors, minitems=3)
+        check_tag_has_at_least_items(tag, software_list, errors, min_items=3)
     for license in licenses_list:
         check_required_fields(license, errors, required_fields=LICENSES_REQUIRED_FIELDS)
     if errors:

--- a/tests/.hecat.awesome_lint.yml
+++ b/tests/.hecat.awesome_lint.yml
@@ -3,7 +3,7 @@ steps:
     module: processors/awesome_lint
     module_options:
       source_directory: tests/awesome-selfhosted-data
-      items_in_redirect_fatal: False
+      # items_in_redirect_fatal: True
       # last_updated_error_days: 3650 # (optional, default 3650) raise an error message for projects that have not been updated in this number of days
       # last_updated_warn_days: 365 # (optional, default 365) raise a warning message for projects that have not been updated in this number of days
       # last_updated_info_days: 186 # (optional, default 186) raise an info message for projects that have not been updated in this number of days


### PR DESCRIPTION
- ref. https://github.com/awesome-selfhosted/awesome-selfhosted-data/pull/164
- ref. https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/163