### PR TITLE
tools/github actions: make workflows compatible with gitea actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,7 @@ jobs:
     steps:
     - name: checkout repo
       uses: actions/checkout@v2
+    - name: install requirements
+      run: sudo apt update && sudo apt -y install python3-venv python3-pip
     - name: run tests
       run: make test_short


### PR DESCRIPTION
- The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package