### PR TITLE
processors/github_metadata: use git commit date instead of author date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+#### [v1.2.2](https://github.com/nodiscc/hecat/releases/tag/1.2.2) - UNERELASED
+
+**Changed:**
+- processors/github_metadata: use git commit date instead of author date
+
+---------------------
+
 #### [v1.2.1](https://github.com/nodiscc/hecat/releases/tag/1.2.1) - 2023-10-27
 
 **Added:**

--- a/hecat/processors/github_metadata.py
+++ b/hecat/processors/github_metadata.py
@@ -58,7 +58,7 @@ def get_gh_metadata(step, github_url, g, errors):
     project = re.sub('/$', '', project)
     try:
         gh_metadata = g.get_repo(project)
-        latest_commit_date = gh_metadata.get_commits()[0].commit.author.date
+        latest_commit_date = gh_metadata.get_commits()[0].commit.committer.date
     except github.GithubException as github_error:
         error_msg = '{} : {}'.format(github_url, github_error)
         logging.error(error_msg)


### PR DESCRIPTION
- https://stackoverflow.com/questions/11856983/why-is-git-authordate-different-from-commitdate
- https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History
- ref. https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/332