### PR TITLE
Improve handling of url_check processor by not failing by a single URL failure

### DIFF
--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -125,7 +125,7 @@ def should_escalate(url, failed_urls_file, escalation_limit):
 
     return False
 
-def handle_failed_url(url, failed_urls_file, escalation_limit):
+def handle_failed_url(url, errors, failed_urls_file, escalation_limit):
     # Load existing failed URLs or create an empty list
     try:
         with open(failed_urls_file, 'r') as file:

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -50,7 +50,7 @@ def check_return_code(url, current_item_index, total_item_count, errors, failed_
             handle_failed_url(url, failed_urls_file, escalation_limit)
             return False
     # Invalid URL should be handled as an error directly
-    except requests.exceptions.InvalidURL as invalid_url_error:
+    except (requests.exceptions.InvalidURL, requests.exceptions.InvalidSchema) as invalid_url_error:
         error_msg = '{} : {}'.format(url, invalid_url_error)
         logging.error('[%s/%s] %s', current_item_index, total_item_count, error_msg)
         handle_failed_url(url, failed_urls_file, escalation_limit)

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -106,22 +106,6 @@ def check_urls(step):
         if 'errors_are_fatal' in step['module_options'].keys() and step['module_options']['errors_are_fatal']:
             sys.exit(1)
 
-def should_escalate(url, failed_urls_file, escalation_limit):
-    # Load existing failed URLs or create an empty list
-    try:
-        with open(failed_urls_file, 'r') as file:
-            failed_urls = [line.strip() for line in file.readlines()]
-    except FileNotFoundError:
-        return False
-
-    # Check if the URL has reached the escalation limit
-    if url in failed_urls:
-        index = failed_urls.index(url)
-        count = int(failed_urls[index + 1])
-        return count >= escalation_limit
-
-    return False
-
 def handle_failed_url(url, errors, failed_urls_file, escalation_limit):
     # Load existing failed URLs or create an empty list
     try:

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -45,7 +45,7 @@ def check_return_code(url, current_item_index, total_item_count, errors, failed_
         else:
             error_msg = '{} : HTTP {}'.format(url, response.status_code)
             logging.warning('[%s/%s] %s', current_item_index, total_item_count, error_msg)
-            handle_failed_url(url, failed_urls_file, escalation_limit)
+            handle_failed_url(url, errors, failed_urls_file, escalation_limit)
             return False
     # Invalid URL should be handled as an error directly
     except (requests.exceptions.InvalidURL, requests.exceptions.InvalidSchema) as invalid_url_error:
@@ -57,7 +57,7 @@ def check_return_code(url, current_item_index, total_item_count, errors, failed_
     except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout, requests.exceptions.ContentDecodingError) as connection_error:
         error_msg = '{} : {}'.format(url, connection_error)
         logging.warning('[%s/%s] %s', current_item_index, total_item_count, error_msg)
-        handle_failed_url(url, failed_urls_file, escalation_limit)
+        handle_failed_url(url, errors, failed_urls_file, escalation_limit)
         return False
 
 def check_urls(step):

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -18,7 +18,7 @@ steps:
         - website_url
         - demo_url
       failed_urls_file: 'failed_urls.txt'  # specify the file to store failed URLs
-      escalation_limit: 3  # specify the limit for escalating from warning to error
+      escalation_limit: 3  # raise an error instead of a warning after this number of consecutive failures on a single URL
       errors_are_fatal: False # (default False) if True exit with error code 1 at the end of processing, if any checks were unsuccessful
       exclude_regex: # (default []) don't check URLs matching these regular expressions
         - '^https://github.com/[\w\.\-]+/[\w\.\-]+$' # don't check URLs that will be processed by the github_metadata module

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -56,10 +56,7 @@ def check_return_code(url, current_item_index, total_item_count, errors, failed_
     # Connection errors should be handled as warnings, but escalate to errors after a certain number of attempts
     except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout, requests.exceptions.ContentDecodingError) as connection_error:
         error_msg = '{} : {}'.format(url, connection_error)
-        if should_escalate(url, failed_urls_file, escalation_limit):
-            logging.error('[%s/%s] %s', current_item_index, total_item_count, error_msg)
-        else:
-            logging.warning('[%s/%s] %s', current_item_index, total_item_count, error_msg)
+        logging.warning('[%s/%s] %s', current_item_index, total_item_count, error_msg)
         handle_failed_url(url, failed_urls_file, escalation_limit)
         return False
 

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -51,7 +51,7 @@ def check_return_code(url, current_item_index, total_item_count, errors, failed_
     except (requests.exceptions.InvalidURL, requests.exceptions.InvalidSchema) as invalid_url_error:
         error_msg = '{} : {}'.format(url, invalid_url_error)
         logging.error('[%s/%s] %s', current_item_index, total_item_count, error_msg)
-        handle_failed_url(url, failed_urls_file, escalation_limit)
+        errors.append(error_msg)
         return False
     # Connection errors should be handled as warnings, but escalate to errors after a certain number of attempts
     except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout, requests.exceptions.ContentDecodingError) as connection_error:

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -95,7 +95,7 @@ def check_urls(step):
                                              step['module_options']['failed_urls_file'],
                                              step['module_options']['escalation_limit']):
                             success_count = success_count + 1
-                            remove_from_failed_urls(item[key_name], step['module_options']['failed_urls_file'])
+                            handle_successful_url(item[key_name], step['module_options']['failed_urls_file'])
                         else:
                             error_count = error_count + 1
                             checked_urls.append(item[key_name])
@@ -150,7 +150,7 @@ def handle_failed_url(url, failed_urls_file, escalation_limit):
     with open(failed_urls_file, 'w') as file:
         file.write('\n'.join(failed_urls))
 
-def remove_from_failed_urls(url, failed_urls_file):
+def handle_successful_url(url, failed_urls_file):
     # Load existing failed URLs or create an empty list
     try:
         with open(failed_urls_file, 'r') as file:

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -139,7 +139,9 @@ def handle_failed_url(url, failed_urls_file, escalation_limit):
         count = int(failed_urls[index + 1]) + 1
         failed_urls[index + 1] = str(count)
         if count >= escalation_limit:
-            logging.error('URL %s reached the escalation limit (%s).', url, escalation_limit)
+            error_msg = 'URL check for {} failed {} times in a row.'.format(url, escalation_limit)
+            logging.error(error_msg)
+            errors.append(error_msg)
     else:
         # Add the URL to the list with count 1
         failed_urls.extend([url, '1'])

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -163,7 +163,6 @@ def remove_from_failed_urls(url, failed_urls_file):
         index = failed_urls.index(url)
         failed_urls.pop(index)
         failed_urls.pop(index)  # Remove the corresponding count
-
-    # Write the updated failed URLs list back to the file
-    with open(failed_urls_file, 'w') as file:
-        file.write('\n'.join(failed_urls))
+        # Write the updated failed URLs list back to the file
+        with open(failed_urls_file, 'w') as file:
+            file.write('\n'.join(failed_urls))

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -120,7 +120,7 @@ def handle_failed_url(url, errors, failed_urls_file, escalation_limit):
         count = int(failed_urls[index + 1]) + 1
         failed_urls[index + 1] = str(count)
         if count >= escalation_limit:
-            error_msg = 'URL check for {} failed {} times in a row.'.format(url, escalation_limit)
+            error_msg = 'URL check for {} failed {} times in a row (Limit: {}).'.format(url, count, escalation_limit)
             logging.error(error_msg)
             errors.append(error_msg)
     else:

--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -37,8 +37,6 @@ VALID_HTTP_CODES = [200, 206]
 
 def check_return_code(url, current_item_index, total_item_count, errors, failed_urls_file, escalation_limit):
     try:
-        # Check if the URL is valid, if valid, proceed with the regular checks
-        requests.get(url, headers={"Range": "bytes=0-200", "User-Agent": "hecat/0.0.1"}, timeout=10)
         # GET only first 200 bytes when possible, servers that do not support the Range: header will simply return the entire page
         response = requests.get(url, headers={"Range": "bytes=0-200", "User-Agent": "hecat/0.0.1"}, timeout=10)
         if response.status_code in VALID_HTTP_CODES:

--- a/tests/.hecat.url_check.yml
+++ b/tests/.hecat.url_check.yml
@@ -12,6 +12,8 @@ steps:
         - source_code_url
         - website_url
         - demo_url
+      failed_urls_file: 'failed_urls.txt'
+      escalation_limit: 3
       errors_are_fatal: False
       exclude_regex:
         - '^https://github.com/[\w\.\-]+/[\w\.\-]+$' # don't check URLs that will be processed by the github_metadata module


### PR DESCRIPTION
Following our brief discussion on [this GitHub thread](https://github.com/awesome-selfhosted/awesome-selfhosted-data/pull/547), I've made some enhancements to the existing URL_check. Instead of triggering a failure after one unsuccessful attempt, the revised system now checks if the same URL has failed in the last X runs. Only after that does it flag an error; otherwise, it simply issues a warning.

I didn't want to modify the system so that it would only raise an error after a total of X URLs had failed. Though this would be beneficial for the badges, it wouldn't identify the exact URL that might need attention, particularly if it had been failing consistently for a week, for instance.

In light of these changes, failure records are now kept in a txt file, listing the number of times a URL has failed. This system will only escalate to an error if the failure count exceeds a certain threshold. However, this necessitated the creation of a new file, failed_urls.txt, which will be used to store this data between runs.

https://cdn.ravshort.com/rEGU2/NOnOcUjE47.png
https://cdn.ravshort.com/rEGU2/wOWIFuyi58.png
https://cdn.ravshort.com/rEGU2/HOWUQeco71.png
https://cdn.ravshort.com/rEGU2/sUgoPenu05.png