### PR TITLE
Use GitHub GraphQL for Metadat fetching (with new metadata fields)

### DIFF
--- a/hecat/processors/github_metadata.py
+++ b/hecat/processors/github_metadata.py
@@ -195,6 +195,10 @@ def add_github_metadata(step):
                 })
             projectindex += 1
             write_software_yaml(step, software)
+
+        # Sleep for the specified amount of time before the next request
+        if 'sleep_time' in step['module_options']:
+            time.sleep(step['module_options']['sleep_time'])
     
     if errors:
         logging.error("There were errors during processing")
@@ -207,12 +211,12 @@ def gh_metadata_cleanup(step):
     logging.info('cleaning up old github metadata from software data')
     # Get the current year and month
     now = datetime.now()
-    year_month = now.strftime("%Y-%m")
+    year_month_12_months_ago = (now.replace(year = now.year - 1)).strftime("%Y-%m")
     # Check if commit_history exists and remove any entries that are older the 12 months
     for software in software_list:
         if 'commit_history' in software:
             for key in list(software['commit_history'].keys()):
-                if key < year_month:
+                if key < year_month_12_months_ago:
                     del software['commit_history'][key]
                     logging.debug('removing commit history %s for %s', key, software['name'])
         write_software_yaml(step, software)


### PR DESCRIPTION
I am currently **trying** to implement https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/84, as well as some other nice-to-have metadata (which I personally would like to see, such as the current release and release date), which means fetching the metadata over the GrapSQL API instead of the Python package used. 

_I don't to anything normally with python so I happy enough that the current code seems to work? There will probably still be a lot to re-write and change. Sorry in advance for the quality of the code._

I didn't get the Batch to be 100 as GitHub already returns an error with 75 or more (I have no clue why).

New metadata preview:
```yaml
name: Convos
website_url: https://convos.chat/
description: Always online web IRC client.
licenses:
  - Artistic-2.0
platforms:
  - Perl
  - Docker
tags:
  - Communication - IRC
source_code_url: https://github.com/convos-chat/convos
demo_url: https://convos.chat/#instant-demo
stargazers_count: 14379
updated_at: '2024-05-03'
archived: false
current_release:
  tag: v1.0.0
  published_at: '2016-10-07'
commit_history:
  2024-05: 13
```