### PR TITLE
utils: to_kebab_case(): trim illegal ms characters

### DIFF
--- a/hecat/utils.py
+++ b/hecat/utils.py
@@ -22,7 +22,14 @@ def to_kebab_case(string):
         '&': '',
         '/': '',
         ',': '',
-        '*': ''
+        '*': '',
+        '\\': '',
+        '<': '',
+        '>': '',
+        '|': '',
+        '?': '',
+        '!': '',
+        '"': '',
     }
     newstring = string.translate(str.maketrans(replacements)).lower()
     return newstring

--- a/hecat/utils.py
+++ b/hecat/utils.py
@@ -28,7 +28,6 @@ def to_kebab_case(string):
         '>': '',
         '|': '',
         '?': '',
-        '!': '',
         '"': '',
     }
     newstring = string.translate(str.maketrans(replacements)).lower()


### PR DESCRIPTION
When running a pull or clone operation on the `awesome-selfhosted-data` repository, it currently fails on Windows devices due to a file containing an invalid character for Windows file names.

This PR addresses the issue by adding the problematic character to the trim list. Additionally, it updates the list to include all other illegal characters for Windows file names to prevent similar issues in the future. (I am pretty sure we already had this issue some time ago.)

```
git clone https://github.com/awesome-selfhosted/awesome-selfhosted-data/
Cloning into 'awesome-selfhosted-data'...
remote: Enumerating objects: 399925, done.
remote: Counting objects: 100% (50785/50785), done.
remote: Compressing objects: 100% (2373/2373), done.
remote: Total 399925 (delta 49668), reused 48994 (delta 48412), pack-reused 349140 (from 1)Receiving objects: 100% (399925/399925), 38.14 MiB | 37.87 MiB/s
Receiving objects: 100% (399925/399925), 46.42 MiB | 38.30 MiB/s, done.
Resolving deltas: 100% (387299/387299), done.
error: invalid path 'software/what-to-cook?.yml'
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'
```