### PR TITLE
utils: load_yaml_data(): only load yaml files

### DIFF
--- a/hecat/utils.py
+++ b/hecat/utils.py
@@ -41,6 +41,9 @@ def load_yaml_data(path, sort_key=False):
     yaml = ruamel.yaml.YAML(typ='rt')
     data = []
     if os.path.isfile(path):
+        if not path.endswith('.yml') and not path.endswith('.yaml'):
+            logging.error('file %s is not a YAML file', path)
+            sys.exit(1)
         logging.debug('loading data from %s', path)
         with open(path, 'r', encoding="utf-8") as yaml_data:
             data = yaml.load(yaml_data)
@@ -49,6 +52,9 @@ def load_yaml_data(path, sort_key=False):
         return data
     elif os.path.isdir(path):
         for file in sorted(list_files(path)):
+            if not file.endswith('.yml') and not file.endswith('.yaml'):
+                logging.debug('skipping file %s, not a YAML file', file)
+                continue
             source_file = path + '/' + file
             logging.debug('loading data from %s', source_file)
             with open(source_file, 'r', encoding="utf-8") as yaml_data:


### PR DESCRIPTION
In the `load_yaml_data` function we now filter for files with the `.yml` or `.yaml` extension. Files which are not yaml files are ignored if possible, an error is only thrown if the file is directly tried to be loaded.

```
DEBUG:utils.py: loading data from awesome-selfhosted-data/software/writing.yml
DEBUG:utils.py: skipping file wrong-file-extention.xml, not a YAML file
DEBUG:utils.py: loading data from awesome-selfhosted-data/software/xandikos.yml

ERROR:utils.py: file awesome-selfhosted-data/software/wrong-file-extention.xml is not a YAML file
```

Closes #139