### PR TITLE
processors/url_check: handel TooManyRedirects exception

### DIFF
--- a/hecat/processors/url_check.py
+++ b/hecat/processors/url_check.py
@@ -45,7 +45,7 @@ def check_return_code(url, current_item_index, total_item_count, errors):
             logging.error('[%s/%s] %s', current_item_index, total_item_count, error_msg)
             errors.append(error_msg)
             return False
-    except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout, requests.exceptions.ContentDecodingError) as connection_error:
+    except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout, requests.exceptions.ContentDecodingError, requests.exceptions.TooManyRedirects) as connection_error:
         error_msg = '{} : {}'.format(url, connection_error)
         logging.error('[%s/%s] %s', current_item_index, total_item_count, error_msg)
         errors.append(error_msg)


### PR DESCRIPTION
requests library has a default set of maximum redirects to 30 (too avoid infinite loops), if the number of redirects exceeds this limit, the request will raise a TooManyRedirects exception.
This exception will now be handled by the url_check processor, by treating it like any other connection_error exception.

should fix https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/1234

Also, I know I probably start annoying you, but you didn't forget #138 ?