### PR TITLE
fix(processor/github_metadata): match repos by full owner/name path

### DIFF
--- a/hecat/processors/github_metadata.py
+++ b/hecat/processors/github_metadata.py
@@ -49,10 +49,15 @@ yaml = ruamel.yaml.YAML(typ='rt')
 yaml.indent(sequence=4, offset=2)
 yaml.width = 99999
 
-def extract_repo_name(url):
-    """extract the repository name from the URL"""
-    re_result = re.search(r'^https?:\/\/github\.com\/[^\/]+\/([^\/]+)\/?$', url)
-    return re_result.group(1) if re_result else None
+def extract_repo_identifier(url):
+    """extract the repository owner/name from the URL"""
+    re_result = re.search(r'^https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/?$', url)
+    if re_result:
+        owner = re_result.group(1)
+        repo = re_result.group(2)
+        return f"{owner}/{repo}"
+    logging.debug('extract_repo_identifier: failed to extract owner/repo from URL: %s', url)
+    return None
 
 def cleanup_old_commit_history(commit_history, months_to_keep=12):
     """Remove commit history entries older than the specified number of months"""
@@ -324,7 +329,7 @@ def add_github_metadata(step):
             repo = edge["repo"]
             software = None
             for project in github_projects:
-                if extract_repo_name(repo["url"]).casefold() == extract_repo_name(project['source_code_url']).casefold():
+                if extract_repo_identifier(repo["url"]).casefold() == extract_repo_identifier(project['source_code_url']).casefold():
                     software = project
                     break
             if not software:


### PR DESCRIPTION
This fixes a bug in the repo matching logic of the metadata fetcher.
Before, I was just using the repo name to match GraphQL response data with the extracted repo from the URL. Problem is, if two repos have the same name, it'd match both and overwrite one repo, giving us bad data. That's what caused the bug in https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues/1828

Now it matches using the owner/repo combo, which is unique so we shouldn't see this issue again. Downside is if a repo gets renamed, matching will break for it, but that should get auto-reported via L336.

Before:
```txt
DEBUG:github_metadata.py: Matched repository https://github.com/gethomepage/homepage to software entry: Homepage by gethomepage
DEBUG:github_metadata.py: Software "Homepage by gethomepage" current metadata - stargazers: 320, updated_at: 2021-05-09, archived: False
DEBUG:github_metadata.py: Software "Homepage by gethomepage" final metadata to be written:
DEBUG:github_metadata.py: Successfully wrote YAML file for software "Homepage by gethomepage"
DEBUG:github_metadata.py: Matched repository https://github.com/tomershvueli/homepage to software entry: Homepage by gethomepage
DEBUG:github_metadata.py: Software "Homepage by gethomepage" current metadata - stargazers: 26977, updated_at: 2025-11-25, archived: False
DEBUG:github_metadata.py: Software "Homepage by gethomepage" final metadata to be written:
DEBUG:github_metadata.py: Successfully wrote YAML file for software "Homepage by gethomepage"
```

After:
```txt
DEBUG:github_metadata.py: Matched repository https://github.com/gethomepage/homepage to software entry: Homepage by gethomepage
DEBUG:github_metadata.py: Software "Homepage by gethomepage" current metadata - stargazers: 320, updated_at: 2021-05-09, archived: False
DEBUG:github_metadata.py: Software "Homepage by gethomepage" final metadata to be written:
DEBUG:github_metadata.py: Successfully wrote YAML file for software "Homepage by gethomepage"
DEBUG:github_metadata.py: Matched repository https://github.com/tomershvueli/homepage to software entry: Homepage by tomershvueli
DEBUG:github_metadata.py: Software "Homepage by tomershvueli" current metadata - stargazers: 320, updated_at: 2021-05-09, archived: False
DEBUG:github_metadata.py: Software "Homepage by tomershvueli" final metadata to be written:
DEBUG:github_metadata.py: Successfully wrote YAML file for software "Homepage by tomershvueli"
```

Doing a quick scan with python, this means that probably 30 repos in our dataset currently have incorrect metadata.

<details>
  <summary>Python Script Results</summary>
  
```txt
[REPO] Repository name: 'server'
   Found 7 projects with 7 different owners:
   - Bitwarden
     URL: https://github.com/bitwarden/server
     Owner/Repo: bitwarden/server
   - Gotify
     URL: https://github.com/gotify/server
     Owner/Repo: gotify/server
   - Nextcloud
     URL: https://github.com/nextcloud/server
     Owner/Repo: nextcloud/server
   - PushBits
     URL: https://github.com/pushbits/server
     Owner/Repo: pushbits/server
   - Screego
     URL: https://github.com/screego/server
     Owner/Repo: screego/server
   - Sync-in
     URL: https://github.com/Sync-in/server
     Owner/Repo: Sync-in/server
   - Traggo
     URL: https://github.com/traggo/server
     Owner/Repo: traggo/server

[REPO] Repository name: 'core'
   Found 4 projects with 4 different owners:
   - Dovecot
     URL: https://github.com/dovecot/core
     Owner/Repo: dovecot/core
   - Gibbon
     URL: https://github.com/GibbonEdu/core
     Owner/Repo: GibbonEdu/core
   - Home Assistant
     URL: https://github.com/home-assistant/core
     Owner/Repo: home-assistant/core
   - ownCloud
     URL: https://github.com/owncloud/core
     Owner/Repo: owncloud/core

[REPO] Repository name: 'app'
   Found 4 projects with 4 different owners:
   - LibreBooking
     URL: https://github.com/LibreBooking/app
     Owner/Repo: LibreBooking/app
   - Mybucks.online
     URL: https://github.com/mybucks-online/app
     Owner/Repo: mybucks-online/app
   - SimpleLogin
     URL: https://github.com/simple-login/app
     Owner/Repo: simple-login/app
   - Standard Notes
     URL: https://github.com/standardnotes/app
     Owner/Repo: standardnotes/app

[REPO] Repository name: 'self-hosted'
   Found 3 projects with 3 different owners:
   - Revolt
     URL: https://github.com/revoltchat/self-hosted
     Owner/Repo: revoltchat/self-hosted
   - UI Bakery
     URL: https://github.com/uibakery/self-hosted
     Owner/Repo: uibakery/self-hosted
   - Webtor
     URL: https://github.com/webtor-io/self-hosted
     Owner/Repo: webtor-io/self-hosted

[REPO] Repository name: 'homepage'
   Found 2 projects with 2 different owners:
   - Homepage by gethomepage
     URL: https://github.com/gethomepage/homepage
     Owner/Repo: gethomepage/homepage
   - Homepage by tomershvueli
     URL: https://github.com/tomershvueli/homepage
     Owner/Repo: tomershvueli/homepage

[REPO] Repository name: 'homer'
   Found 2 projects with 2 different owners:
   - Homer
     URL: https://github.com/bastienwirtz/homer
     Owner/Repo: bastienwirtz/homer
   - SIPCAPTURE Homer
     URL: https://github.com/sipcapture/homer
     Owner/Repo: sipcapture/homer

[REPO] Repository name: 'platform'
   Found 2 projects with 2 different owners:
   - Huly
     URL: https://github.com/hcengineering/platform
     Owner/Repo: hcengineering/platform
   - Syncloud
     URL: https://github.com/syncloud/platform
     Owner/Repo: syncloud/platform

[REPO] Repository name: 'medusa'
   Found 2 projects with 2 different owners:
   - Medusa
     URL: https://github.com/pymedusa/Medusa
     Owner/Repo: pymedusa/Medusa
   - MedusaJs
     URL: https://github.com/medusajs/medusa
     Owner/Repo: medusajs/medusa

[REPO] Repository name: 'panel'
   Found 2 projects with 2 different owners:
   - Pelican Panel
     URL: https://github.com/pelican-dev/panel
     Owner/Repo: pelican-dev/panel
   - Pterodactyl
     URL: https://github.com/pterodactyl/panel
     Owner/Repo: pterodactyl/panel

[REPO] Repository name: 'analytics'
   Found 2 projects with 2 different owners:
   - Plausible Analytics
     URL: https://github.com/plausible/analytics/
     Owner/Repo: plausible/analytics
   - Prisme Analytics
     URL: https://github.com/prismelabs/analytics
     Owner/Repo: prismelabs/analytics

================================================================================
SUMMARY:
  Total conflicting repository names: 10
  Total projects potentially affected: 30
================================================================================
```

</details>

Just a heads up, even after merging this, it'll only partially fix things since we're currently only updating the last 3 months of the commit_history. We're already at 4 months now, so some data is still wrong. If you are fine with it, I would run the metadafetcher manually once to fix this with 4 months (or honestly, since I'm doing it manually anyway, I could go ahead and do the full 12 months to have a complete dataset).
