### PR TITLE
feat: add icon download processor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,7 @@ jobs:
     steps:
     - name: checkout repo
       uses: actions/checkout@v2
+    - name: install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y imagemagick
     - name: run tests
       run: make test_short

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,6 @@ install:
 
 ##### TESTS #####
 
-.PHONY: test # run tests
-test: test_pylint clean test_import_shaarli test_download_video test_download_audio test_export_html_table clone_awesome_selfhosted test_import_awesome_selfhosted test_process_awesome_selfhosted test_awesome_lint test_export_awesome_selfhosted_md test_export_awesome_selfhosted_html test_archive_webpages scan_trivy
-
-test_short: test_pylint clean test_import_shaarli test_archive_webpages test_download_video test_download_audio test_export_html_table clone_awesome_selfhosted test_awesome_lint test_export_awesome_selfhosted_md test_export_awesome_selfhosted_html
-
 .PHONY: test # run all tests
 test: test_short test_long
 
@@ -32,7 +27,7 @@ test_short: clean test_import_shaarli test_archive_webpages test_download_video 
     clone_awesome_selfhosted test_download_icons test_export_awesome_selfhosted_md test_awesome_lint \
     test_export_awesome_selfhosted_html
 
-.PHONY: test_short # run long tests
+.PHONY: test_long # run long tests
 test_long: test_process_awesome_selfhosted
 
 .PHONY: test_pylint # run linter (non blocking)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: test_short test_long
 
 .PHONY: test_short # run tests except those that consume github API requests/long URL checks
 test_short: clean test_import_shaarli test_archive_webpages test_download_video test_download_audio test_export_html_table \
-    clone_awesome_selfhosted test_export_awesome_selfhosted_md test_awesome_lint \
+    clone_awesome_selfhosted test_download_icons test_export_awesome_selfhosted_md test_awesome_lint \
     test_export_awesome_selfhosted_html
 
 .PHONY: test_short # run long tests

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test_import_awesome_selfhosted: install
 	hecat --config tests/.hecat.import_awesome_selfhosted_nonfree.yml
 
 .PHONY: test_process_awesome_selfhosted # test all processing steps on awesome-selfhosted-data
-test_process_awesome_selfhosted: install test_url_check test_update_software_metadata test_awesome_lint
+test_process_awesome_selfhosted: install test_url_check test_update_software_metadata test_download_icons test_awesome_lint
 	cd tests/awesome-selfhosted-data && git --no-pager diff --color=always
 
 .PHONY: test_url_check # test URL checker on awesome-sefhosted-data
@@ -71,6 +71,11 @@ test_update_software_metadata: install
 test_awesome_lint: install
 	source .venv/bin/activate && \
 	hecat --config tests/.hecat.awesome_lint.yml
+
+.PHONY: test_download_icons # test icon downloader processor on awesome-selfhosted-data
+test_download_icons: install
+	source .venv/bin/activate && \
+	hecat --config tests/.hecat.download_icons.yml
 
 .PHONY: test_export_awesome_selfhosted_md # test export to singlepage markdown from awesome-selfhosted-data
 test_export_awesome_selfhosted_md: install

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,10 @@ test_awesome_lint: install
 
 .PHONY: test_download_icons # test icon downloader processor on awesome-selfhosted-data
 test_download_icons: install
+	echo 'icon_url: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/jellyfin.webp' >> tests/awesome-selfhosted-data/software/jellyfin.yml
 	source .venv/bin/activate && \
 	hecat --config tests/.hecat.download_icons.yml
+	identify tests/awesome-selfhosted-data/icons/jellyfin.webp
 
 .PHONY: test_export_awesome_selfhosted_md # test export to singlepage markdown from awesome-selfhosted-data
 test_export_awesome_selfhosted_md: install

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Import data from various input formats:
 Perform processing tasks on YAML data:
 
 - [processors/software_metadata](hecat/processors/software_metadata.py): enrich software project metadata from GitHub and GitLab APIs (stars, last commit date...)
+- [processors/download_icons](hecat/processors/download_icons.py): download icons from software `icon_url` entries and convert them to webp
 - [processors/awesome_lint](hecat/processors/awesome_lint.py): check data against [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted) consistency/completeness guidelines
 - [processors/download_media](hecat/processors/download_media.py): download video/audio files using [yt-dlp](https://github.com/yt-dlp/yt-dlp) for bookmarks imported from Shaarli
 - [processors/url_check](hecat/processors/url_check.py): check data for dead links
@@ -470,6 +471,7 @@ test_import_awesome_selfhosted          test import from awesome-sefhosted
 test_process_awesome_selfhosted         test all processing steps on awesome-selfhosted-data
 test_url_check      test URL checker on awesome-sefhosted-data
 test_update_software_metadata             test software metadata updater/processor on awesome-selfhosted-data
+test_download_icons                       test downloading icons from software on awesome-selfhosted-data
 test_awesome_lint   test linter/compliance checker on awesome-sefhosted-data
 test_export_awesome_selfhosted_md       test export to singlepage markdown from awesome-selfhosted-data
 test_export_awesome_selfhosted_html     test export to singlepage HTML from awesome-selfhosted-data

--- a/hecat/main.py
+++ b/hecat/main.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 from .utils import load_yaml_data
 from .importers import import_markdown_awesome, import_shaarli_json
-from .processors import software_metadata, awesome_lint, check_urls, download_media, archive_webpages
+from .processors import software_metadata, awesome_lint, check_urls, download_media, download_icons, archive_webpages
 from .exporters import render_markdown_singlepage, render_html_table
 from .exporters import render_markdown_multipage
 
@@ -45,6 +45,8 @@ def main():
             archive_webpages(step)
         elif step['module'] == 'processors/download_media':
             download_media(step)
+        elif step['module'] == 'processors/download_icons':
+            download_icons(step)
         elif step['module'] == 'exporters/markdown_singlepage':
             render_markdown_singlepage(step)
         elif step['module'] == 'exporters/html_table':

--- a/hecat/processors/__init__.py
+++ b/hecat/processors/__init__.py
@@ -2,5 +2,6 @@
 from .software_metadata import software_metadata
 from .awesome_lint import awesome_lint
 from .download_media import download_media
+from .download_icons import download_icons
 from .url_check import check_urls
 from .archive_webpages import archive_webpages

--- a/hecat/processors/awesome_lint.py
+++ b/hecat/processors/awesome_lint.py
@@ -278,7 +278,7 @@ def awesome_lint(step):
         for filename in files:
             single_yaml_data = load_yaml_data(os.path.join(root, filename))
             check_filename_is_kebab_case_software_name(filename, single_yaml_data, errors)
-            if filename.casefold().endswith('.yml'):
+            if filename.endswith('.yml'):
                 expected_icon_stems.add(os.path.splitext(filename)[0])
     icons_directory = os.path.join(step['module_options']['source_directory'], 'icons')
     if not os.path.isdir(icons_directory):

--- a/hecat/processors/awesome_lint.py
+++ b/hecat/processors/awesome_lint.py
@@ -217,6 +217,16 @@ def check_filename_is_kebab_case_software_name(filename, single_yaml_data, error
         message = '{}: file should be named {}'.format(filename, to_kebab_case(single_yaml_data['name'] + '.yml'))
         log_exception(message, errors, severity=logging.error)
 
+
+def check_icon_has_matching_software(icon, expected_icon_stems, errors):
+    """check that the .webp icon file has a matching software YAML file"""
+    stem, extension = os.path.splitext(icon)
+    if extension.casefold() != '.webp':
+        return
+    if stem not in expected_icon_stems:
+        message = '{}: is a dangling icon file, it has no matching software YAML'.format(icon)
+        log_exception(message, errors, severity=logging.error)
+
 def awesome_lint(step):
     """check all software entries against formatting guidelines"""
     logging.info('checking software entries/tags against formatting guidelines.')
@@ -263,10 +273,20 @@ def awesome_lint(step):
         check_boolean_attributes(software, errors)
     for license in licenses_list:
         check_required_fields(license, errors, required_fields=LICENSES_REQUIRED_FIELDS)
+    expected_icon_stems = set()
     for (root, dirs, files) in os.walk(step['module_options']['source_directory'] + '/software'):
         for filename in files:
             single_yaml_data = load_yaml_data(os.path.join(root, filename))
             check_filename_is_kebab_case_software_name(filename, single_yaml_data, errors)
+            if filename.casefold().endswith('.yml'):
+                expected_icon_stems.add(os.path.splitext(filename)[0])
+    icons_directory = os.path.join(step['module_options']['source_directory'], 'icons')
+    if not os.path.isdir(icons_directory):
+        logging.debug('icon directory %s does not exist, skipping dangling icon check', icons_directory)
+    else:
+        icon_list = sorted(os.listdir(icons_directory))
+        for icon in icon_list:
+            check_icon_has_matching_software(icon, expected_icon_stems, errors)
     if errors:
         logging.error("There were errors during processing")
         sys.exit(1)

--- a/hecat/processors/download_icons.py
+++ b/hecat/processors/download_icons.py
@@ -55,13 +55,13 @@ DEFAULT_RETRY_STATUS_FORCELIST = (429, 500, 502, 503, 504)
 
 # Allowed input types
 ALLOWED_IMAGE_TYPES = {
-    'PNG':  {'image/png'},
+    'PNG': {'image/png'},
     'JPEG': {'image/jpeg'},
     'WEBP': {'image/webp'},
-    'GIF':  {'image/gif'},
-    'BMP':  {'image/bmp'},
+    'GIF': {'image/gif'},
+    'BMP': {'image/bmp'},
     'TIFF': {'image/tiff'},
-    'ICO':  {'image/x-icon', 'image/vnd.microsoft.icon'},
+    'ICO': {'image/x-icon', 'image/vnd.microsoft.icon'},
 }
 
 # Configuration helpers

--- a/hecat/processors/download_icons.py
+++ b/hecat/processors/download_icons.py
@@ -283,11 +283,11 @@ def convert_image_to_webp(temp_path, destination_path, output_size, allowed_imag
             resized.save(tmp_destination, **save_kwargs)
             os.replace(tmp_destination, destination_path)
     except UnidentifiedImageError as exc:
-        remove_temp_file(tmp_destination)
         return f'downloaded file is not a valid image: {exc}'
     except ValueError as exc:
-        remove_temp_file(tmp_destination)
         return f'failed converting or saving icon: {exc}'
+    finally:
+        remove_temp_file(tmp_destination)
     return None
 
 def remove_temp_file(temp_path):

--- a/hecat/processors/download_icons.py
+++ b/hecat/processors/download_icons.py
@@ -10,7 +10,7 @@ steps:
       output_directory: tests/awesome-selfhosted-data/icons     # (default <source_directory>/icons) output directory for .webp icons
       skip_when_icon_present: True                              # (default True) skip entries whose .webp already exists
       output_size: 128                                          # (default 128) target square size in pixels
-      max_download_bytes: 5242880                               # (default 5 MiB) hard cap on bytes downloaded per icon
+      max_download_bytes: 2097152                               # (default 2 MiB) hard cap on bytes downloaded per icon
       max_image_pixels: 4194304                                 # (default 4 Mpx) reject sources whose width*height exceeds this; prevents decompression bombs
       request_timeout: 15                                       # (default 15) per-request timeout in seconds
       webp_quality: 85                                          # (default 85) lossy WEBP quality 0-100; only used for opaque non-icon-art sources
@@ -219,7 +219,7 @@ def convert_image_to_webp(temp_path, destination_path, output_size, allowed_imag
     """verify image type, resize within output_size while keeping aspect ratio, pad to a square output_size x output_size canvas, and save as WEBP atomically.
 
     Encoder choice is per-source-format: lossless WEBP for sources with alpha or in {PNG, ICO, GIF, BMP}; lossy WEBP for photographic sources (JPEG, opaque WEBP).
-    For multi-frame ICO files, the largest available frame is used. Truncated source images are rejected (Pillow default behavior)
+    Truncated source images are rejected (Pillow default behavior)
     """
     tmp_destination = destination_path + '.tmp'
     try:
@@ -235,14 +235,6 @@ def convert_image_to_webp(temp_path, destination_path, output_size, allowed_imag
                 expected_mimes = allowed_image_types.get(detected_format, set())
                 if server_mime not in expected_mimes:
                     return f'MIME mismatch: server said {server_mime}, file decoded as {detected_format}'
-
-            # for multi-resolution ICOs, switch to the largest available frame
-            if detected_format == 'ICO' and getattr(image, 'ico', None) is not None:
-                sizes = image.ico.sizes()
-                if sizes:
-                    best = max(sizes)
-                    logging.debug('ICO frames available: %s; selected largest: %s', sorted(sizes), best)
-                    image.size = best
 
             # decompression-bomb guard
             width, height = image.size
@@ -336,6 +328,9 @@ def download_icons(step):
     """download and normalize software icons from icon_url fields"""
     errors = []
     source_directory = get_module_option(step, 'source_directory', None)
+    if not source_directory:
+        logging.error('module option source_directory is required')
+        sys.exit(1)
     output_directory = get_module_option(step, 'output_directory', f'{source_directory}/icons')
     allowed_mime_types = {mime.casefold() for mimes in ALLOWED_IMAGE_TYPES.values() for mime in mimes}
     allowed_image_formats = set(ALLOWED_IMAGE_TYPES)

--- a/hecat/processors/download_icons.py
+++ b/hecat/processors/download_icons.py
@@ -1,0 +1,378 @@
+"""download_icons processor
+Downloads icons from software `icon_url` entries and converts them to webp.
+
+# hecat.yml
+steps:
+  - name: download icons
+    module: processors/download_icons
+    module_options:
+      source_directory: tests/awesome-selfhosted-data
+      output_directory: tests/awesome-selfhosted-data/icons     # (default <source_directory>/icons) output directory for .webp icons
+      skip_when_icon_present: True                              # (default True) skip entries whose .webp already exists
+      output_size: 128                                          # (default 128) target square size in pixels
+      max_download_bytes: 5242880                               # (default 5 MiB) hard cap on bytes downloaded per icon
+      max_image_pixels: 4194304                                 # (default 4 Mpx) reject sources whose width*height exceeds this; prevents decompression bombs
+      request_timeout: 15                                       # (default 15) per-request timeout in seconds
+      webp_quality: 85                                          # (default 85) lossy WEBP quality 0-100; only used for opaque non-icon-art sources
+      webp_method: 6                                            # (default 6) WEBP encoder effort 0-6; 6=slowest/smallest
+      retry_total: 2                                            # (default 2) max retries for transient failures (5xx, 429, connection errors)
+      retry_backoff_factor: 1                                   # (default 1) urllib3 backoff factor between retries
+      retry_status_forcelist: [429, 500, 502, 503, 504]         # (default same) HTTP statuses that should trigger a retry
+"""
+
+import os
+import sys
+import tempfile
+import logging
+from pathlib import Path
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+from PIL import Image, ImageOps, UnidentifiedImageError
+from ..utils import load_yaml_data
+
+# Defaults
+DEFAULT_MAX_DOWNLOAD_BYTES = 2 * 1024 * 1024 # 2 MiB
+DEFAULT_MAX_IMAGE_PIXELS = 2048 * 2048 # 4 Mpx, prevents decompression-bomb DoS
+DEFAULT_REQUEST_TIMEOUT = 15
+DEFAULT_SKIP_WHEN_ICON_PRESENT = True
+DEFAULT_OUTPUT_SIZE = 128
+DEFAULT_WEBP_QUALITY = 85
+DEFAULT_WEBP_METHOD = 6
+DEFAULT_RETRY_TOTAL = 2
+DEFAULT_RETRY_BACKOFF_FACTOR = 1
+DEFAULT_RETRY_STATUS_FORCELIST = (429, 500, 502, 503, 504)
+
+# Allowed input types
+ALLOWED_IMAGE_TYPES = {
+    'PNG':  {'image/png'},
+    'JPEG': {'image/jpeg'},
+    'WEBP': {'image/webp'},
+    'GIF':  {'image/gif'},
+    'BMP':  {'image/bmp'},
+    'TIFF': {'image/tiff'},
+    'ICO':  {'image/x-icon', 'image/vnd.microsoft.icon'},
+}
+
+# Configuration helpers
+def get_module_option(step, key, default):
+    """return a module option value or its default"""
+    return step['module_options'].get(key, default)
+
+def build_retrying_session(retry_total, retry_backoff_factor, retry_status_forcelist):
+    """build a requests.Session with retries on transient failures (5xx, 429, connection errors)"""
+    retry = Retry(
+        total=retry_total,
+        backoff_factor=retry_backoff_factor,
+        status_forcelist=tuple(retry_status_forcelist),
+        allowed_methods=('HEAD', 'GET'),
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
+
+def iter_software_entries_with_stem(source_directory):
+    """return a list of (software, yaml stem, yaml path) tuples for every YAML in <source_directory>/software"""
+    software_directory = Path(source_directory) / 'software'
+    if not software_directory.is_dir():
+        return []
+    software_entries = []
+    for yaml_path in sorted(software_directory.glob('*.yml')):
+        software = load_yaml_data(str(yaml_path))
+        software_entries.append((software, yaml_path.stem, yaml_path))
+    return software_entries
+
+# HTTP header parsing
+def normalize_content_type(content_type):
+    """normalize content-type to a lowercase mime type without parameters"""
+    if content_type is None:
+        return None
+    return content_type.split(';', 1)[0].strip().lower()
+
+def validate_content_type(content_type, allowed_mime_types, source_label):
+    """validate content-type against a strict mime whitelist"""
+    if content_type is None:
+        return None
+    normalized_type = normalize_content_type(content_type)
+    if normalized_type not in allowed_mime_types:
+        return f'{source_label}: MIME type not allowed: {normalized_type}'
+    return None
+
+def parse_content_length(content_length):
+    """parse content-length header value and return integer bytes"""
+    if content_length is None:
+        return None, None
+    try:
+        parsed = int(content_length)
+    except ValueError:
+        return None, f'invalid Content-Length header: {content_length}'
+    if parsed < 0:
+        return None, f'invalid negative Content-Length header: {content_length}'
+    return parsed, None
+
+# HTTP request handling
+def preflight_head(session, icon_url, timeout, max_download_bytes, allowed_mime_types):
+    """run a head preflight check and validate response headers if available
+
+    Status-code policy:
+    - exception (DNS / connection / SSL): can't tell, fall through to GET so a transient network blip doesn't kill the entry.
+    - 405 / 501: server doesn't support HEAD; fall through to GET.
+    - 5xx: transient origin error; fall through to GET (the session adapter retries).
+    - any other >= 400 (404, 403, 410, ...): definitive client-side error from the origin; block here so we don't waste a GET round trip on an entry that the origin already told us is unreachable.
+    """
+    try:
+        logging.debug('running HEAD preflight for %s', icon_url)
+        response = session.head(icon_url, allow_redirects=True, timeout=timeout)
+    except requests.exceptions.RequestException as exc:
+        logging.warning('HEAD preflight failed for %s (%s); proceeding to GET without preflight', icon_url, exc)
+        return None
+    status = response.status_code
+    logging.debug('HEAD %s -> status=%s, final_url=%s, Content-Type=%r, Content-Length=%r', icon_url, status, response.url, response.headers.get('Content-Type'), response.headers.get('Content-Length'))
+
+    if status in (405, 501):
+        logging.warning('HEAD not supported for %s (HTTP %s); proceeding to GET without preflight', icon_url, status)
+        return None
+    if 500 <= status < 600:
+        logging.warning('HEAD preflight returned HTTP %s for %s; proceeding to GET (transient)', status, icon_url)
+        return None
+    if status >= 400:
+        return f'HEAD preflight rejected by origin with HTTP status {status}'
+
+    mime_error = validate_content_type(response.headers.get('Content-Type'), allowed_mime_types, 'HEAD response')
+    if mime_error is not None:
+        return mime_error
+    content_length, content_length_error = parse_content_length(response.headers.get('Content-Length'))
+    if content_length_error is not None:
+        return content_length_error
+    if content_length is not None and content_length > max_download_bytes:
+        return f'HEAD response Content-Length {content_length} exceeds limit {max_download_bytes}'
+
+    logging.debug('HEAD preflight successful for %s', icon_url)
+    return None
+
+def download_icon_to_temp(session, icon_url, output_directory, timeout, max_download_bytes, allowed_mime_types):
+    """download icon data to a temporary file with strict byte cap enforcement. On any error return, the temp file is cleaned up before returning"""
+    temp_file = tempfile.NamedTemporaryFile(dir=output_directory, suffix='.download', delete=False)
+    temp_path = temp_file.name
+    temp_file.close()
+    logging.debug('allocated tempfile %s for %s', temp_path, icon_url)
+    bytes_written = 0
+    server_mime = None
+    try:
+        logging.debug('starting icon download for %s', icon_url)
+        with session.get(icon_url, allow_redirects=True, stream=True, timeout=timeout) as response:
+            logging.debug('GET %s -> status=%s, final_url=%s, Content-Type=%r, Content-Length=%r', icon_url, response.status_code, response.url, response.headers.get('Content-Type'), response.headers.get('Content-Length'))
+
+            if response.status_code >= 400:
+                remove_temp_file(temp_path)
+                return None, None, f'download request failed with HTTP status {response.status_code}'
+
+            raw_content_type = response.headers.get('Content-Type')
+            mime_error = validate_content_type(raw_content_type, allowed_mime_types, 'GET response')
+            if mime_error is not None:
+                remove_temp_file(temp_path)
+                return None, None, mime_error
+
+            server_mime = normalize_content_type(raw_content_type)
+            if server_mime is None:
+                logging.info('%s: no Content-Type header on GET response, relying on file content sniff', icon_url)
+
+            content_length, content_length_error = parse_content_length(response.headers.get('Content-Length'))
+            if content_length_error is not None:
+                remove_temp_file(temp_path)
+                return None, None, content_length_error
+            if content_length is not None and content_length > max_download_bytes:
+                remove_temp_file(temp_path)
+                return None, None, f'GET response Content-Length {content_length} exceeds limit {max_download_bytes}'
+
+            with open(temp_path, 'wb') as temp_output:
+                for chunk in response.iter_content(chunk_size=16384):
+                    if not chunk:
+                        continue
+                    bytes_written += len(chunk)
+                    if bytes_written > max_download_bytes:
+                        remove_temp_file(temp_path)
+                        return None, None, f'download exceeded max_download_bytes limit ({max_download_bytes})'
+                    temp_output.write(chunk)
+
+        logging.debug('download completed for %s (%s bytes)', icon_url, bytes_written)
+    except requests.exceptions.RequestException as exc:
+        remove_temp_file(temp_path)
+        return None, None, f'download request failed: {exc}'
+    return temp_path, server_mime, None
+
+# Image processing
+def convert_image_to_webp(temp_path, destination_path, output_size, allowed_image_formats, server_mime, allowed_image_types, max_image_pixels, webp_quality, webp_method):
+    """verify image type, resize within output_size while keeping aspect ratio, pad to a square output_size x output_size canvas, and save as WEBP atomically.
+
+    Encoder choice is per-source-format: lossless WEBP for sources with alpha or in {PNG, ICO, GIF, BMP}; lossy WEBP for photographic sources (JPEG, opaque WEBP).
+    For multi-frame ICO files, the largest available frame is used. Truncated source images are rejected (Pillow default behavior)
+    """
+    tmp_destination = destination_path + '.tmp'
+    try:
+        logging.debug('converting icon file %s to %s', temp_path, destination_path)
+        with Image.open(temp_path) as image:
+            detected_format = (image.format or '').upper()
+            logging.debug('Pillow opened %s: format=%s mode=%s size=%s bands=%s', temp_path, detected_format, image.mode, image.size, image.getbands())
+            if detected_format not in allowed_image_formats:
+                return f'detected image format not allowed: {detected_format or "unknown"}'
+
+            # cross-check server-declared MIME against Pillow's sniffed format
+            if server_mime is not None:
+                expected_mimes = allowed_image_types.get(detected_format, set())
+                if server_mime not in expected_mimes:
+                    return f'MIME mismatch: server said {server_mime}, file decoded as {detected_format}'
+
+            # for multi-resolution ICOs, switch to the largest available frame
+            if detected_format == 'ICO' and getattr(image, 'ico', None) is not None:
+                sizes = image.ico.sizes()
+                if sizes:
+                    best = max(sizes)
+                    logging.debug('ICO frames available: %s; selected largest: %s', sorted(sizes), best)
+                    image.size = best
+
+            # decompression-bomb guard
+            width, height = image.size
+            if width * height > max_image_pixels:
+                return f'image too large: {width}x{height} exceeds {max_image_pixels} pixels'
+
+            # don't force an unused alpha channel onto opaque sources (e.g. JPEG photos)
+            has_alpha = 'A' in image.getbands() or image.info.get('transparency') is not None
+            target_mode = 'RGBA' if has_alpha else 'RGB'
+            logging.debug('alpha=%s -> target_mode=%s', has_alpha, target_mode)
+
+            resized = image.convert(target_mode)
+            pre_thumb_size = resized.size
+            resized.thumbnail((output_size, output_size), Image.Resampling.LANCZOS)
+            logging.debug('thumbnailed %s -> %s (target box=%dx%d)', pre_thumb_size, resized.size, output_size, output_size)
+
+            # normalize to a square output_size x output_size canvas without stretching
+            pad_color = (0, 0, 0, 0) if target_mode == 'RGBA' else (255, 255, 255)
+            resized = ImageOps.pad(
+                resized,
+                (output_size, output_size),
+                color=pad_color,
+                centering=(0.5, 0.5),
+            )
+
+            # per-source encoder split: Lossy on photos, lossless on icon-like art
+            save_kwargs = {'format': 'WEBP', 'method': webp_method}
+            if has_alpha or detected_format in {'PNG', 'ICO', 'GIF', 'BMP'}:
+                save_kwargs['lossless'] = True
+            else:
+                save_kwargs['quality'] = webp_quality
+
+            icc_profile = image.info.get('icc_profile')
+            if icc_profile:
+                save_kwargs['icc_profile'] = icc_profile
+            logging.debug('saving WEBP with kwargs=%s (icc_profile=%s bytes)', {k: v for k, v in save_kwargs.items() if k != 'icc_profile'}, len(icc_profile) if icc_profile else 0)
+
+            resized.save(tmp_destination, **save_kwargs)
+            os.replace(tmp_destination, destination_path)
+    except UnidentifiedImageError as exc:
+        remove_temp_file(tmp_destination)
+        return f'downloaded file is not a valid image: {exc}'
+    except ValueError as exc:
+        remove_temp_file(tmp_destination)
+        return f'failed converting or saving icon: {exc}'
+    return None
+
+def remove_temp_file(temp_path):
+    """delete a temporary file and log a warning on cleanup failure"""
+    if temp_path and os.path.exists(temp_path):
+        try:
+            os.remove(temp_path)
+        except (FileNotFoundError, PermissionError) as exc:
+            logging.warning('failed to remove temporary file %s: %s', temp_path, exc)
+
+# Per-entry processing
+def process_single_icon(session, software, yaml_stem, icon_path, output_directory, options):
+    """download and process a single software icon entry"""
+    icon_url = software.get('icon_url')
+
+    if not icon_url:
+        return 'skipped_no_icon_url'
+    if options['skip_when_icon_present'] and icon_path.exists():
+        return 'skipped_existing_icon'
+    logging.debug('processing entry stem=%s name=%r icon_url=%s -> %s', yaml_stem, software.get('name'), icon_url, icon_path)
+
+    head_error = preflight_head(session, icon_url, options['request_timeout'], options['max_download_bytes'], options['allowed_mime_types'])
+    if head_error is not None:
+        return head_error
+
+    temp_path = None
+    try:
+        temp_path, server_mime, download_error = download_icon_to_temp(session, icon_url, output_directory, options['request_timeout'], options['max_download_bytes'], options['allowed_mime_types'])
+        if download_error is not None:
+            return download_error
+
+        conversion_error = convert_image_to_webp(
+            temp_path, str(icon_path), options['output_size'],
+            options['allowed_image_formats'], server_mime, options['allowed_image_types'],
+            options['max_image_pixels'], options['webp_quality'], options['webp_method'])
+        if conversion_error is not None:
+            return conversion_error
+
+    finally:
+        remove_temp_file(temp_path)
+    logging.info('saved icon for %s at %s', software.get('name', yaml_stem), icon_path)
+    return 'downloaded'
+
+# Main function
+def download_icons(step):
+    """download and normalize software icons from icon_url fields"""
+    errors = []
+    source_directory = get_module_option(step, 'source_directory', None)
+    output_directory = get_module_option(step, 'output_directory', f'{source_directory}/icons')
+    allowed_mime_types = {mime.casefold() for mimes in ALLOWED_IMAGE_TYPES.values() for mime in mimes}
+    allowed_image_formats = set(ALLOWED_IMAGE_TYPES)
+    options = {
+        'request_timeout': get_module_option(step, 'request_timeout', DEFAULT_REQUEST_TIMEOUT),
+        'max_download_bytes': get_module_option(step, 'max_download_bytes', DEFAULT_MAX_DOWNLOAD_BYTES),
+        'max_image_pixels': get_module_option(step, 'max_image_pixels', DEFAULT_MAX_IMAGE_PIXELS),
+        'skip_when_icon_present': get_module_option(step, 'skip_when_icon_present', DEFAULT_SKIP_WHEN_ICON_PRESENT),
+        'output_size': get_module_option(step, 'output_size', DEFAULT_OUTPUT_SIZE),
+        'webp_quality': get_module_option(step, 'webp_quality', DEFAULT_WEBP_QUALITY),
+        'webp_method': get_module_option(step, 'webp_method', DEFAULT_WEBP_METHOD),
+        'allowed_mime_types': allowed_mime_types,
+        'allowed_image_formats': allowed_image_formats,
+        'allowed_image_types': ALLOWED_IMAGE_TYPES,
+    }
+
+    Path(output_directory).mkdir(parents=True, exist_ok=True)
+    software_entries = iter_software_entries_with_stem(source_directory)
+    if not software_entries:
+        logging.error('software directory does not exist or is empty: %s/software', source_directory)
+        sys.exit(1)
+    logging.debug('processing %s software YAML entries for icon downloads', len(software_entries))
+    session = build_retrying_session(
+        get_module_option(step, 'retry_total', DEFAULT_RETRY_TOTAL),
+        get_module_option(step, 'retry_backoff_factor', DEFAULT_RETRY_BACKOFF_FACTOR),
+        get_module_option(step, 'retry_status_forcelist', DEFAULT_RETRY_STATUS_FORCELIST),
+    )
+    processed_count = 0
+    skipped_count = 0
+    error_count = 0
+
+    for software, yaml_stem, yaml_path in software_entries:
+        icon_path = Path(output_directory) / f'{yaml_stem}.webp'
+        result = process_single_icon(session, software, yaml_stem, icon_path, output_directory, options)
+        if result == 'downloaded':
+            processed_count += 1
+        elif result.startswith('skipped_'):
+            skipped_count += 1
+            logging.debug('%s: %s', yaml_path, result)
+        else:
+            error_count += 1
+            error_msg = f'{yaml_path}: {result}'
+            logging.error(error_msg)
+            errors.append(error_msg)
+    logging.info('icon processing complete. Downloaded: %s - Skipped: %s - Errors: %s', processed_count, skipped_count, error_count)
+
+    if errors:
+        logging.error("errors occurred during processing")
+        print('\n'.join(errors))
+        sys.exit(1)

--- a/hecat/processors/download_icons.py
+++ b/hecat/processors/download_icons.py
@@ -287,7 +287,7 @@ def remove_temp_file(temp_path):
     if temp_path and os.path.exists(temp_path):
         try:
             os.remove(temp_path)
-        except (FileNotFoundError, PermissionError) as exc:
+        except PermissionError as exc:
             logging.warning('failed to remove temporary file %s: %s', temp_path, exc)
 
 # Per-entry processing

--- a/hecat/processors/download_icons.py
+++ b/hecat/processors/download_icons.py
@@ -18,6 +18,16 @@ steps:
       retry_total: 2                                            # (default 2) max retries for transient failures (5xx, 429, connection errors)
       retry_backoff_factor: 1                                   # (default 1) urllib3 backoff factor between retries
       retry_status_forcelist: [429, 500, 502, 503, 504]         # (default same) HTTP statuses that should trigger a retry
+
+
+source_directory: path to directory where data files reside. Directory structure:
+├── software
+│   ├── mysoftware.yml # .yml files containing software data
+│   ├── someothersoftware.yml
+│   └── ...
+├── icons
+│   ├── mysoftware.webp # .webp icons
+└── ...
 """
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'ruamel.yaml==0.17.21',
         'python-dateutil',
         'requests',
+        'Pillow',
         'yt_dlp',
         'jinja2',
         'Markdown',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'ruamel.yaml==0.17.21',
         'python-dateutil',
         'requests',
-        'Pillow',
+        'Pillow==11.1.0',
         'yt_dlp',
         'jinja2',
         'Markdown',

--- a/tests/.hecat.download_icons.yml
+++ b/tests/.hecat.download_icons.yml
@@ -1,0 +1,8 @@
+steps:
+  - name: download icons
+    module: processors/download_icons
+    module_options:
+      source_directory: tests/awesome-selfhosted-data
+      output_directory: tests/awesome-selfhosted-data/icons
+      output_size: 128
+      skip_when_icon_present: True


### PR DESCRIPTION
- adds a new processor `download_icons.py`
- updates documentation and tests

---

This adds the discussed icon downloader from #157. It currently:

- Walks `<source_directory>/software/*.yml`, reads each entry's `icon_url`, downloads it, and writes a square WebP to `<output_directory>/<yaml-name>.webp`
- Downloads have several safeguards: a HEAD preflight check (which is allowed to fail since some sites block HEAD requests and which turns out that is not uncommon), a hard byte cap enforced during the download, and a content validation pass after the download completes
- Resizes within a target box (default 128×128) preserving aspect ratio, then pads to a square canvas (transparent for RGBA sources, white for opaque) so all output files have the same dimensions
- Encoding is split into two paths, a lossless WebP for alpha sources and `{PNG, ICO, GIF, BMP}` (which is what most icons actually are), and lossy WebP at quality 85 for opaque JPEG/WEBP (the lossy branch only exists because when I tested it, encoding a JPEG icon losslessly actually doubled the output size for some reason)
- Picks the largest frame for multi-resolution `.ico` sources
- Preserves source ICC profiles when present
- Skips entries whose `.webp` already exists by default (`skip_when_icon_present: True`)
- Adds an additional check in `awesome_lint` that flags `.webp` files in `icons/` with no matching software YAML (dangling-icon detection)

One deviation from what was originally discussed: instead of the warn-mostly behavior mentioned in the issue, this errors out on failures instead. That probably makes more sense for a pipeline and matches the existing behavior of the other processors much better anyway.

---

I also did some testing around size and format. I had AI generate a benchmark to check whether PNG or WebP made more sense in practice. The data comes from an import of [dashboard-icons](https://github.com/homarr-labs/dashboard-icons) where I added the WebP URL to every project matched, so the benchmark ran across 467 icons. Unless otherwise noted, all values below are means.


| At 128×128 | WebP | PNG |
|---|---|---|
| Lossless | 7.3 KiB | 10.3 KiB (+29%) |
| Lossy / quantized | 3.9 KiB (q85) | 4.7 KiB (256-color) (+17%) |


| Size | WebP bytes | vs 128 |
|---|---|---|
| 64 | 3.0 KiB | 41% |
| 96 | 5.1 KiB | 70% |
| **128** | **7.3 KiB** | **baseline** |
| 192 | 12.6 KiB | 173% |
| 256 | 17.8 KiB | 244% |

<details>

## Run metadata

- Source directory: `tests/awesome-selfhosted-data`
- Entries discovered: 1309
- Entries successfully encoded: 467
- Entries rejected: 842
- Sizes benchmarked: 64, 96, 128, 192, 256
- Variants benchmarked: webp-current, webp-lossy-q85, webp-lossy-q90, png-current, png-lossless, png-quantized
- Wall-clock time: 2798.6s

## At-a-glance: mean bytes per icon (and sum across encoded entries)

| Variant | 64px | 96px | 128px | 192px | 256px |
|---|---|---|---|---|---|
| webp-current | 3.0 KiB (sum 1.4 MiB) | 5.1 KiB (sum 2.3 MiB) | 7.3 KiB (sum 3.3 MiB) | 12.6 KiB (sum 5.7 MiB) | 17.8 KiB (sum 8.1 MiB) |
| webp-lossy-q85 | 1.8 KiB (sum 854.8 KiB) | 2.9 KiB (sum 1.3 MiB) | 3.9 KiB (sum 1.8 MiB) | 6.0 KiB (sum 2.8 MiB) | 8.2 KiB (sum 3.7 MiB) |
| webp-lossy-q90 | 2.0 KiB (sum 942.5 KiB) | 3.2 KiB (sum 1.4 MiB) | 4.3 KiB (sum 2.0 MiB) | 6.7 KiB (sum 3.1 MiB) | 9.2 KiB (sum 4.2 MiB) |
| png-current | 4.2 KiB (sum 1.9 MiB) | 7.1 KiB (sum 3.2 MiB) | 10.3 KiB (sum 4.7 MiB) | 17.5 KiB (sum 8.0 MiB) | 25.3 KiB (sum 11.5 MiB) |
| png-lossless | 4.3 KiB (sum 1.9 MiB) | 7.2 KiB (sum 3.3 MiB) | 10.4 KiB (sum 4.8 MiB) | 17.8 KiB (sum 8.1 MiB) | 25.8 KiB (sum 11.8 MiB) |
| png-quantized | 2.3 KiB (sum 1.0 MiB) | 3.4 KiB (sum 1.6 MiB) | 4.7 KiB (sum 2.1 MiB) | 7.7 KiB (sum 3.5 MiB) | 10.9 KiB (sum 5.0 MiB) |

## Per-size detail

### 64x64

| Variant | mean | median | p95 | p99 | max | sum across encoded |
|---|---|---|---|---|---|---|
| webp-current | 3.0 KiB | 2.7 KiB | 5.9 KiB | 7.0 KiB | 7.9 KiB | 1.4 MiB |
| webp-lossy-q85 | 1.8 KiB | 1.8 KiB | 3.1 KiB | 3.7 KiB | 4.7 KiB | 854.8 KiB |
| webp-lossy-q90 | 2.0 KiB | 2.0 KiB | 3.4 KiB | 4.0 KiB | 5.0 KiB | 942.5 KiB |
| png-current | 4.2 KiB | 4.0 KiB | 7.4 KiB | 8.5 KiB | 10.2 KiB | 1.9 MiB |
| png-lossless | 4.3 KiB | 4.1 KiB | 7.4 KiB | 8.5 KiB | 10.2 KiB | 1.9 MiB |
| png-quantized | 2.3 KiB | 2.3 KiB | 3.5 KiB | 4.1 KiB | 4.6 KiB | 1.0 MiB |

### 96x96

| Variant | mean | median | p95 | p99 | max | sum across encoded |
|---|---|---|---|---|---|---|
| webp-current | 5.1 KiB | 4.5 KiB | 10.7 KiB | 13.1 KiB | 14.6 KiB | 2.3 MiB |
| webp-lossy-q85 | 2.9 KiB | 2.8 KiB | 5.0 KiB | 6.1 KiB | 8.3 KiB | 1.3 MiB |
| webp-lossy-q90 | 3.2 KiB | 3.1 KiB | 5.6 KiB | 6.7 KiB | 9.0 KiB | 1.4 MiB |
| png-current | 7.1 KiB | 6.6 KiB | 13.7 KiB | 16.3 KiB | 19.3 KiB | 3.2 MiB |
| png-lossless | 7.2 KiB | 6.7 KiB | 14.0 KiB | 16.3 KiB | 19.3 KiB | 3.3 MiB |
| png-quantized | 3.4 KiB | 3.4 KiB | 5.9 KiB | 7.0 KiB | 8.6 KiB | 1.6 MiB |

### 128x128

| Variant | mean | median | p95 | p99 | max | sum across encoded |
|---|---|---|---|---|---|---|
| webp-current | 7.3 KiB | 6.2 KiB | 15.9 KiB | 20.4 KiB | 22.3 KiB | 3.3 MiB |
| webp-lossy-q85 | 3.9 KiB | 3.7 KiB | 7.1 KiB | 9.2 KiB | 12.3 KiB | 1.8 MiB |
| webp-lossy-q90 | 4.3 KiB | 4.1 KiB | 7.8 KiB | 10.1 KiB | 13.4 KiB | 2.0 MiB |
| png-current | 10.3 KiB | 9.3 KiB | 20.9 KiB | 26.0 KiB | 29.3 KiB | 4.7 MiB |
| png-lossless | 10.4 KiB | 9.4 KiB | 21.3 KiB | 26.0 KiB | 29.3 KiB | 4.8 MiB |
| png-quantized | 4.7 KiB | 4.5 KiB | 8.8 KiB | 10.8 KiB | 13.3 KiB | 2.1 MiB |

### 192x192

| Variant | mean | median | p95 | p99 | max | sum across encoded |
|---|---|---|---|---|---|---|
| webp-current | 12.6 KiB | 10.6 KiB | 29.3 KiB | 35.7 KiB | 40.7 KiB | 5.7 MiB |
| webp-lossy-q85 | 6.0 KiB | 5.7 KiB | 11.1 KiB | 14.5 KiB | 19.7 KiB | 2.8 MiB |
| webp-lossy-q90 | 6.7 KiB | 6.5 KiB | 12.5 KiB | 16.0 KiB | 21.7 KiB | 3.1 MiB |
| png-current | 17.5 KiB | 15.3 KiB | 38.0 KiB | 48.3 KiB | 53.5 KiB | 8.0 MiB |
| png-lossless | 17.8 KiB | 15.3 KiB | 39.7 KiB | 48.3 KiB | 53.5 KiB | 8.1 MiB |
| png-quantized | 7.7 KiB | 7.1 KiB | 16.0 KiB | 19.9 KiB | 27.8 KiB | 3.5 MiB |

### 256x256

| Variant | mean | median | p95 | p99 | max | sum across encoded |
|---|---|---|---|---|---|---|
| webp-current | 17.8 KiB | 14.7 KiB | 42.5 KiB | 55.1 KiB | 62.5 KiB | 8.1 MiB |
| webp-lossy-q85 | 8.2 KiB | 7.8 KiB | 15.2 KiB | 22.2 KiB | 27.9 KiB | 3.7 MiB |
| webp-lossy-q90 | 9.2 KiB | 8.7 KiB | 17.0 KiB | 24.5 KiB | 30.4 KiB | 4.2 MiB |
| png-current | 25.3 KiB | 21.5 KiB | 55.6 KiB | 73.4 KiB | 85.3 KiB | 11.5 MiB |
| png-lossless | 25.8 KiB | 21.6 KiB | 59.7 KiB | 73.4 KiB | 85.3 KiB | 11.8 MiB |
| png-quantized | 10.9 KiB | 9.8 KiB | 23.4 KiB | 30.9 KiB | 47.7 KiB | 5.0 MiB |

## Source-size distribution (pre-processing)

Use this to pick a sensible `max_download_bytes` cap — the p99 row tells you the smallest cap that would accept ~99% of real icons.

| stat | bytes |
|---|---|
| count | 467 |
| mean | 36.1 KiB |
| median | 27.0 KiB |
| p95 | 96.2 KiB |
| p99 | 170.1 KiB |
| max | 267.2 KiB |

## Source format breakdown

| source format | count | share |
|---|---|---|
| WEBP | 467 | 100.0% |

| has alpha channel | count | share |
|---|---|---|
| yes | 453 | 97.0% |
| no | 14 | 3.0% |

## Rejection breakdown

| reason | count |
|---|---|
| missing_icon_url | 842 |

</details>

--- 

To test it, you can use the current `awesome-selfhosted-repo`, run my [dashboard-icons import script](https://gist.github.com/Rabenherz112/4960c8e279337935a386e5da4b9e867e) to populate `icon_url` fields, then run hecat against it.
